### PR TITLE
fix: clear notify_url value in payment object to avoid incorrect URL …

### DIFF
--- a/lib/features/checkout/data/services/payhere_service.dart
+++ b/lib/features/checkout/data/services/payhere_service.dart
@@ -21,7 +21,7 @@ class PayHereService {
         "sandbox": AppConfig.payHereIsSandbox,
         "merchant_id": AppConfig.payHereMerchantId,
         "merchant_secret": AppConfig.payHereMerchantSecret,
-        "notify_url": "https://neatcomputer.lk/wp-json/wc/v3/payhere/notify",
+        "notify_url": "",
         "order_id": orderId,
         "items": "Order #$orderId",
         "amount": amount.toString(),


### PR DESCRIPTION
### What Changed
- Removed the notify_url value from payment object to avoid sending incorrect URLs.

### Why
- The notify_url was mistakenly added before.
- This cleanup ensures correct PayHere integration.

### Type of Change
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
